### PR TITLE
Lagt till filtrering för taggarna på filmsidan

### DIFF
--- a/src/Features/handleTagFilter.js
+++ b/src/Features/handleTagFilter.js
@@ -1,0 +1,34 @@
+export function initTagFilter({
+  store,
+  clearMovies,
+  renderFilteredMovieList
+}) {
+  const buttons = document.querySelectorAll(".tagsbtn");
+
+  buttons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      
+      buttons.forEach((b) => b.classList.remove("active"));
+
+      btn.classList.add("active");
+
+      const tag = btn.textContent.trim();
+      let moviesToShow = [];
+
+      if (tag === "Aktuellt") {
+        moviesToShow = store.nowPlaying;
+      }
+
+      if (tag === "Barnfilmer") {
+        moviesToShow = store.kids;
+      }
+
+      if (tag === "Klassiker") {
+        moviesToShow = store.classics;
+      }
+
+      clearMovies();
+      renderFilteredMovieList(moviesToShow);
+    });
+  });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,8 @@ import { createPoster } from "./Features/createPoster";
 import { initGenres, getGenreNames } from "./API/genreID";
 import { handleLiveSearch } from "./Features/handleLiveSearch";
 import { bindBackdrops, initCarousel } from "./Features/carousel";
+import { initTagFilter } from "./Features/handleTagFilter";
+
 
 // 1. Hämta all data först (Genrer och Filmer)
 await initGenres();
@@ -110,6 +112,13 @@ if (moviesWrapper && searchInput && searchBtn) {
 
 // 4. Slutligen, rendera posters (nu när containern garanterat finns)
 renderMovies();
+
+initTagFilter({
+  store,
+  clearMovies,
+  renderFilteredMovieList
+});
+
 
 function renderMovies() {
   if (!moviesWrapper) return;


### PR DESCRIPTION
Har lagt till logik för filtrering av filmer via tagg knappar (Aktuellt, Barnfilmer, Klassiker).
Lösningen återanvänder befintlig render och search logik utan att ändra tidigare arbete.
Endast en tagg kan vara aktiv åt gången. 
